### PR TITLE
Allow PayPal Checkout without supplying an address

### DIFF
--- a/src/gateways/Gateway.php
+++ b/src/gateways/Gateway.php
@@ -239,43 +239,49 @@ class Gateway extends BaseGateway
         }
 
         // After authorize - update order with email/address/taxes
-        $payer = $apiResponse->result->payer;
-        $order = $transaction->order;
-        $order->email = $payer->email_address;
+        try {
+            $order = $transaction->order;
+            $payer = $apiResponse->result->payer;
+            $order->email = $payer->email_address;
 
-        $shipping = $apiResponse->result->purchase_units[0]->shipping->address;
+            $shipping = $apiResponse->result->purchase_units[0]->shipping->address;
 
-        $countryObj = Plugin::getInstance()->getCountries()->getCountryByIso($shipping->country_code);
-        $stateObj = Plugin::getInstance()->getStates()->getStateByAbbreviation($countryObj->id, $shipping->admin_area_1);
-        $address = new Address();
-        $address->firstName = $payer->name->given_name;
-        $address->lastName = $payer->name->surname;
-        $address->phone = $payer->phone->phone_number->national_number;
-        $address->address1 = $shipping->address_line_1;
-        $address->address2 = $shipping->address_line_2 ?? "";
-        $address->city = $shipping->admin_area_2;
-        $address->zipCode = $shipping->postal_code;
-        $address->stateId = $stateObj->id;
-        $address->countryId = $countryObj->id;
+            $countryObj = Plugin::getInstance()->getCountries()->getCountryByIso($shipping->country_code);
+            $stateObj = Plugin::getInstance()->getStates()->getStateByAbbreviation($countryObj->id, $shipping->admin_area_1);
 
-        $order->setShippingAddress($address);
-        $order->setBillingAddress($address);
+            $address = new Address();
+            $address->firstName = $payer->name->given_name;
+            $address->lastName = $payer->name->surname;
+            $address->phone = $payer->phone->phone_number->national_number;
+            $address->address1 = $shipping->address_line_1;
+            $address->address2 = $shipping->address_line_2 ?? "";
+            $address->city = $shipping->admin_area_2;
+            $address->zipCode = $shipping->postal_code;
+            $address->stateId = $stateObj->id;
+            $address->countryId = $countryObj->id;
 
-        // Recalculate to get the relevant tax
-        $order->setRecalculationMode(Order::RECALCULATION_MODE_ADJUSTMENTS_ONLY);
-        $order->recalculate();
-        $order->setRecalculationMode(Order::RECALCULATION_MODE_NONE);
+            $order->setShippingAddress($address);
+            $order->setBillingAddress($address);
 
-        $successSaving = Craft::$app->getElements()->saveElement($order, true);
+            // Recalculate to get the relevant tax
+            $order->setRecalculationMode(Order::RECALCULATION_MODE_ADJUSTMENTS_ONLY);
+            $order->recalculate();
+            $order->setRecalculationMode(Order::RECALCULATION_MODE_NONE);
 
-        if ($successSaving) {
-            // Make sure our transaction is updated to include tax
-            $paymentCurrency = Plugin::getInstance()->getPaymentCurrencies()->getPaymentCurrencyByIso($order->paymentCurrency);
-            $transaction->amount = $order->getTotalPrice();
-            $transaction->paymentAmount = Currency::round($order->getTotalPrice() * $paymentCurrency->rate, $paymentCurrency);
-        } else {
-            Craft::error('FAILED VALIDATING ORDER! ' . json_encode($order->getErrors()));
-            throw new PaymentException('Failed saving authorized order!');
+            $successSaving = Craft::$app->getElements()->saveElement($order, true);
+
+            if ($successSaving) {
+                // Make sure our transaction is updated to include tax
+                $paymentCurrency = Plugin::getInstance()->getPaymentCurrencies()->getPaymentCurrencyByIso($order->paymentCurrency);
+                $transaction->amount = $order->getTotalPrice();
+                $transaction->paymentAmount = Currency::round($order->getTotalPrice() * $paymentCurrency->rate, $paymentCurrency);
+            } else {
+                Craft::error('FAILED VALIDATING ORDER! ' . json_encode($order->getErrors()));
+                throw new PaymentException('Failed saving authorized order!');
+            }
+        } catch (\Exception $e) {
+            Craft::error('FAILED UPDATING ORDER AFTER AUTHORIZED! ' . json_encode($order->getErrors()));
+            throw new PaymentException($e->getMessage());
         }
 
         return $this->getResponseModel($apiResponse);

--- a/src/gateways/Gateway.php
+++ b/src/gateways/Gateway.php
@@ -240,6 +240,7 @@ class Gateway extends BaseGateway
 
         // After authorize - update order with email/address/taxes
         $payer = $apiResponse->result->payer;
+        $order = $transaction->order;
         $order->email = $payer->email_address;
 
         $shipping = $apiResponse->result->purchase_units[0]->shipping->address;

--- a/src/gateways/Gateway.php
+++ b/src/gateways/Gateway.php
@@ -540,7 +540,8 @@ class Gateway extends BaseGateway
 
         $requestData['purchase_units'] = $this->_buildPurchaseUnits($order, $transaction);
 
-        $shippingPreference = isset($requestData['purchase_units'][0]['shipping']) && !empty($requestData['purchase_units'][0]['shipping']) && isset($requestData['purchase_units'][0]['shipping']['address']) ? 'SET_PROVIDED_ADDRESS' : 'GET_FROM_FILE';
+        //$shippingPreference = isset($requestData['purchase_units'][0]['shipping']) && !empty($requestData['purchase_units'][0]['shipping']) && isset($requestData['purchase_units'][0]['shipping']['address']) ? 'SET_PROVIDED_ADDRESS' : 'GET_FROM_FILE';
+        $shippingPreference = 'GET_FROM_FILE';
 
         $requestData['application_context'] = [
             'brand_name' => $this->brandName,

--- a/src/gateways/Gateway.php
+++ b/src/gateways/Gateway.php
@@ -238,6 +238,45 @@ class Gateway extends BaseGateway
             throw new PaymentException($e->getMessage());
         }
 
+        // After authorize - update order with email/address/taxes
+        $payer = $apiResponse->result->payer;
+        $order->email = $payer->email_address;
+
+        $shipping = $apiResponse->result->purchase_units[0]->shipping->address;
+
+        $countryObj = Plugin::getInstance()->getCountries()->getCountryByIso($shipping->country_code);
+        $stateObj = Plugin::getInstance()->getStates()->getStateByAbbreviation($countryObj->id, $shipping->admin_area_1);
+        $address = new Address();
+        $address->firstName = $payer->name->given_name;
+        $address->lastName = $payer->name->surname;
+        $address->phone = $payer->phone->phone_number->national_number;
+        $address->address1 = $shipping->address_line_1;
+        $address->address2 = $shipping->address_line_2 ?? "";
+        $address->city = $shipping->admin_area_2;
+        $address->zipCode = $shipping->postal_code;
+        $address->stateId = $stateObj->id;
+        $address->countryId = $countryObj->id;
+
+        $order->setShippingAddress($address);
+        $order->setBillingAddress($address);
+
+        // Recalculate to get the relevant tax
+        $order->setRecalculationMode(Order::RECALCULATION_MODE_ADJUSTMENTS_ONLY);
+        $order->recalculate();
+        $order->setRecalculationMode(Order::RECALCULATION_MODE_NONE);
+
+        $successSaving = Craft::$app->getElements()->saveElement($order, true);
+
+        if ($successSaving) {
+            // Make sure our transaction is updated to include tax
+            $paymentCurrency = Plugin::getInstance()->getPaymentCurrencies()->getPaymentCurrencyByIso($order->paymentCurrency);
+            $transaction->amount = $order->getTotalPrice();
+            $transaction->paymentAmount = Currency::round($order->getTotalPrice() * $paymentCurrency->rate, $paymentCurrency);
+        } else {
+            Craft::error('FAILED VALIDATING ORDER! ' . json_encode($order->getErrors()));
+            throw new PaymentException('Failed saving authorized order!');
+        }
+
         return $this->getResponseModel($apiResponse);
     }
 
@@ -500,7 +539,7 @@ class Gateway extends BaseGateway
 
         $requestData['purchase_units'] = $this->_buildPurchaseUnits($order, $transaction);
 
-        $shippingPreference = isset($requestData['purchase_units'][0]['shipping']) && !empty($requestData['purchase_units'][0]['shipping']) && isset($requestData['purchase_units'][0]['shipping']['address']) ? 'SET_PROVIDED_ADDRESS' : 'NO_SHIPPING';
+        $shippingPreference = isset($requestData['purchase_units'][0]['shipping']) && !empty($requestData['purchase_units'][0]['shipping']) && isset($requestData['purchase_units'][0]['shipping']['address']) ? 'SET_PROVIDED_ADDRESS' : 'GET_FROM_FILE';
 
         $requestData['application_context'] = [
             'brand_name' => $this->brandName,
@@ -654,16 +693,17 @@ class Gateway extends BaseGateway
         /** @var Address $shippingAddress */
         $billingAddress = $order->billingAddress;
 
-        $return = [
-            'email_address' => $order->email,
-        ];
+        $return = [];
+        if ($order->email) {
+            $return['email_address'] = $order->email;
+        }
 
         $name = [];
-        if ($billingAddress->fullName || $billingAddress->firstName) {
+        if ($billingAddress && ($billingAddress->fullName || $billingAddress->firstName)) {
             $name['given_name'] = $billingAddress->fullName ?: $billingAddress->firstName;
         }
 
-        if (!$billingAddress->fullName && $billingAddress->lastName) {
+        if ($billingAddress && (!$billingAddress->fullName && $billingAddress->lastName)) {
             $name['surname'] = $billingAddress->lastName;
         }
 

--- a/src/resources/js/paymentForm.js
+++ b/src/resources/js/paymentForm.js
@@ -54,8 +54,9 @@ function initPaypalCheckout() {
                     },
                     dataType: 'json'
                 }).then(function(response) {
-                    if (!response.cart.shippingAddressId) {
-                        console.error('error updating address!');
+
+                    if (response.error) {
+                        console.error('error! ' + response.error + '(' + JSON.stringify(response.errors) + ')');
                         return actions.reject();
                     }
 

--- a/src/resources/js/paymentForm.js
+++ b/src/resources/js/paymentForm.js
@@ -16,14 +16,16 @@ function initPaypalCheckout() {
         var completeUrl = $wrapper.dataset.complete;
         var transactionHash;
         var errorShown = false;
+        var screenWidth = $(window).width();
 
         paypal_checkout_sdk.Buttons({
             style: {
                 layout:  'horizontal',
                 color:   'white',
-                shape:   'rect',
+                shape:   screenWidth > 767 ? 'pill' : 'rect',
                 tagline: 'false',
-                label:   'paypal'
+                label:   'paypal',
+                size: 'responsive'
             },
 
             // https://developer.paypal.com/docs/checkout/integration-features/shipping-callback)

--- a/src/resources/js/paymentForm.js
+++ b/src/resources/js/paymentForm.js
@@ -56,7 +56,7 @@ function initPaypalCheckout() {
                 }).then(function(response) {
 
                     if (response.error) {
-                        console.error('error! ' + response.error + '(' + JSON.stringify(response.errors) + ')');
+                        console.error('error! ' + response.error + ' (' + JSON.stringify(response.errors) + ')');
                         return actions.reject();
                     }
 

--- a/src/resources/js/paymentForm.js
+++ b/src/resources/js/paymentForm.js
@@ -229,10 +229,10 @@ function initPaypalCheckout() {
                     type: 'GET',
                     url: completeUrl + separator + 'commerceTransactionHash=' + transactionHash,
                     beforeSend: function() {
-                        $(".modal-overlay").show();
+                        $(".pending-payment-modal-overlay").show();
                     },
                     complete: function() {
-                        $(".modal-overlay").hide();
+                        $(".pending-payment-modal-overlay").hide();
                     },
                     success: function(data) {
                         // Note: we don't actually expect to get here, we should get 302 upon success. Added here just to be on the safe side.

--- a/src/resources/js/paymentForm.js
+++ b/src/resources/js/paymentForm.js
@@ -94,7 +94,7 @@ function initPaypalCheckout() {
                     dataType: 'json'
                 }).then(function(response) {
                     if (response && response.cart && response.cart.lineItems && response.cart.lineItems.length === 0) {
-                        let product = $(".pay-button").closest(".paymentSource-form").siblings(".add-to-cart-button-container").attr("product"),
+                        let product = $($form).closest(".paypal-button-container").attr("product"),
                             deviceColor = $("input[type=radio][name=" + product + "-device-color]:checked").prop("value"),
                             deviceSize  = $("input[type=radio][name=" + product + "-device-size]:checked").prop("value"),
                             purchasable = $("input[name=" + product + "-varients][deviceColor=" + deviceColor + "][deviceSize=" + deviceSize + "]"),

--- a/src/resources/js/paymentForm.js
+++ b/src/resources/js/paymentForm.js
@@ -79,6 +79,11 @@ function initPaypalCheckout() {
             },
 
             onClick: function(data, actions) {
+                gtag('event', 'PayPal Checkout', {
+                    'event_category' : 'Commerce',
+                    'event_label' : 'Wristcam'
+                });
+
                 var csrfToken = $("[name=CRAFT_CSRF_TOKEN]").prop("value");
                     path = "/" + window.location.pathname.split("/").filter(i => !!i).join("/");
 

--- a/src/resources/js/paymentForm.js
+++ b/src/resources/js/paymentForm.js
@@ -103,10 +103,12 @@ function initPaypalCheckout() {
             },
 
             onClick: function(data, actions) {
-                gtag('event', 'PayPal Checkout', {
-                    'event_category' : 'Commerce',
-                    'event_label' : 'Wristcam'
+                dataLayer.push({
+                  'event': 'PayPal Checkout',
+                  'event_category' : 'Commerce',
+                  'event_label' : 'Wristcam'
                 });
+
                 var csrfToken = $("[name=CRAFT_CSRF_TOKEN]").prop("value");
                     path = "/" + window.location.pathname.split("/").filter(i => !!i).join("/");
 

--- a/src/resources/js/paymentForm.js
+++ b/src/resources/js/paymentForm.js
@@ -157,13 +157,20 @@ function initPaypalCheckout() {
                         }
 
                         // Logic
-                        // If in cart page action with non empty cart
+                        // If in cart page action
                         // If no line items, add selected item to cart
                         // If single line item, qty 1 and different than button, replace it
                         // If single line item, qty 1 and same as button, no need to update
                         // otherwise, go to cart page
-                        if(window.location.pathname.startsWith('/cart') && response.cart.totalQty > 0) {
-                            return actions.resolve();
+                        if(window.location.pathname.startsWith('/cart')) {
+                            //If not empty cart - resolve
+                            //otherwise - reject
+                            if(response.cart.totalQty > 0) {
+                                return actions.resolve();
+                            }
+                            else {
+                                return actions.reject();
+                            }
                         } else if (response.cart.lineItems.length === 0) {
                             // set selected item to cart
                             return updateCartSingleItem();

--- a/src/resources/js/paymentForm.js
+++ b/src/resources/js/paymentForm.js
@@ -169,6 +169,8 @@ function initPaypalCheckout() {
                                 return actions.resolve();
                             }
                             else {
+                                $("#paypal-card-errors").removeClass("hidden");
+                                $("#paypal-card-errors").text("Your cart is empty. Please add a product before purchasing.");
                                 return actions.reject();
                             }
                         } else if (response.cart.lineItems.length === 0) {

--- a/src/resources/js/paymentForm.js
+++ b/src/resources/js/paymentForm.js
@@ -176,8 +176,29 @@ function initPaypalCheckout() {
                 if (completeUrl.indexOf('?') >= 0) {
                     separator = '&';
                 }
+                $.ajax({
+                    type: 'GET',
+                    url: completeUrl + separator + 'commerceTransactionHash=' + transactionHash,
+                    success: function(data) {
+                        // Note: we don't actually expect to get here, we should get 302 upon success. Added here just to be on the safe side.
+                        window.location = completeUrl + separator + 'commerceTransactionHash=' + transactionHash;
+                    },
+                    error: function(jqXHR, textStatus, errorThrown) {
+                        if (jqXHR.status === 302) {
+                            window.location = jqXHR.getResponseHeader('x-redirect');
+                            return;
+                        }
 
-                window.location = completeUrl + separator + 'commerceTransactionHash=' + transactionHash;
+                        $("#paypal-card-errors").removeClass("hidden");
+                        $("#paypal-card-errors").html("Payment failed!</BR>Please try again or contact our <a href='mailto:support@wristcam.com' target='_blank'>Support</a>");
+
+                        // Show alert after the page updates with the error html
+                        setTimeout(function(){
+                            alert("Payment failed! Please try again or contact our support.");
+                        }, 200);
+                    }
+                });
+
             }
         }).render('#paypal-button-container');
     }

--- a/src/resources/js/paymentForm.js
+++ b/src/resources/js/paymentForm.js
@@ -107,7 +107,6 @@ function initPaypalCheckout() {
                     'event_category' : 'Commerce',
                     'event_label' : 'Wristcam'
                 });
-
                 var csrfToken = $("[name=CRAFT_CSRF_TOKEN]").prop("value");
                     path = "/" + window.location.pathname.split("/").filter(i => !!i).join("/");
 
@@ -229,6 +228,12 @@ function initPaypalCheckout() {
                 $.ajax({
                     type: 'GET',
                     url: completeUrl + separator + 'commerceTransactionHash=' + transactionHash,
+                    beforeSend: function() {
+                        $(".modal-overlay").show();
+                    },
+                    complete: function() {
+                        $(".modal-overlay").hide();
+                    },
                     success: function(data) {
                         // Note: we don't actually expect to get here, we should get 302 upon success. Added here just to be on the safe side.
                         window.location = completeUrl + separator + 'commerceTransactionHash=' + transactionHash;

--- a/src/resources/js/paymentForm.js
+++ b/src/resources/js/paymentForm.js
@@ -157,11 +157,14 @@ function initPaypalCheckout() {
                         }
 
                         // Logic
+                        // If in cart page action with non empty cart
                         // If no line items, add selected item to cart
                         // If single line item, qty 1 and different than button, replace it
                         // If single line item, qty 1 and same as button, no need to update
                         // otherwise, go to cart page
-                        if (response.cart.lineItems.length === 0) {
+                        if(window.location.pathname.startsWith('/cart') && response.cart.totalQty > 0) {
+                            return actions.resolve();
+                        } else if (response.cart.lineItems.length === 0) {
                             // set selected item to cart
                             return updateCartSingleItem();
                         } else if (response.cart.lineItems.length === 1 && response.cart.lineItems[0].qty === 1) {
@@ -176,6 +179,8 @@ function initPaypalCheckout() {
                             window.location = "/cart";
                             return actions.reject();
                         }
+
+
                     } else {
                         // Error getting cart?!
                         console.error('error getting cart! ' + JSON.stringify(response));


### PR DESCRIPTION
Allow PayPal to provide the address. Validate shipping address and update tax as shipping address changes. Auto-insert item to cart if needed.